### PR TITLE
feat: ignore whitespaces at the end of title #PLTM-233

### DIFF
--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -4,7 +4,7 @@
  */
 const getTasks = (source) => {
   // Matches the prefix of the string containg only issue references delimited with whitespaces
-  const prefixWithRefsRegex = /((\s+|^)#[A-Z]{2,10}-\d+)+$/;
+  const prefixWithRefsRegex = /((\s+|^)#[A-Z]{2,10}-\d+)+\s*$/;
   const [prefix] = source.match(prefixWithRefsRegex) || [''];
   // Picks individual issue references from the string
   const taskRefRegex = /(?<=(\s|^)#)[A-Z]{2,10}-\d+/g;

--- a/lib/get-tasks.spec.js
+++ b/lib/get-tasks.spec.js
@@ -8,6 +8,12 @@ const correctSources = [
     ]
   ],
   [
+    "This PR closes #BUNNY-1   ",
+    [
+      { taskId: "BUNNY-1" }
+    ]
+  ],
+  [
     "This PR has duplicated reference #BUNNY-1 #BUNNY-1",
     [
       { taskId: "BUNNY-1" },


### PR DESCRIPTION
## Why

Kanar will fail to parse issue references if a whitespace is left at the end of PR title. This can lead to confusion and frustration, as extra whitespace is not easy to spot.