### PR TITLE
fix: broken fail message formatting

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -61,14 +61,21 @@ const checkTasks = async () => {
 
   const tasksWithName = allTasks.filter(({ name }) => name);
   if (tasksWithName.length === 0) {
-    fail(
-      `<b>Please add the Jira issue key at the end of PR title e.g.: #DATA-98</b> (remember to add hash)
-      
-      <i>You can find issue key eg. in the last part of URL when issue is viewed in the browser eg.:
-      URL: ${JIRA_BASE_URL}/browse/DATA-98 -> issue key: DATA-98 -> what should be added to the PR title: #DATA-98
-      
-      You can add more than one issue key in the PR title.</i>`
-    );
+    fail(`
+      <p>
+        <b>Please add the Jira issue key at the end of PR title e.g.: #DATA-98</b> (remember to add hash)
+      </p>
+      <p>
+        <i>
+          You can find issue key eg. in the last part of URL when issue is viewed in the browser eg.:
+          URL: ${JIRA_BASE_URL}/browse/DATA-98 -> issue key: DATA-98 -> what should be added to the PR title: #DATA-98
+        </i>
+      </p>
+      <p>
+        <i>
+          You can add more than one issue key in the PR title.
+        </i>
+      </p>`);
     console.error("::error::No Jira issue key found in PR title");
     return;
   }


### PR DESCRIPTION
Error message when no Jira issue key is found is incorrectly formatted due to trailing whitespaces:

![image](https://github.com/user-attachments/assets/3c7a8151-75ee-4eca-b1b4-ee910985c5d7)

Wrapping each line in `<p>` tag solves an issue.