### PR TITLE
fix formatting of task list

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -82,6 +82,7 @@ const checkTasks = async () => {
 
   message(
     `Jira issue(s) related to this PR:
+    
     ${tasksWithName
       .map(
         ({ taskId, name }) =>


### PR DESCRIPTION
github's markdown requires an empty line before a list to start formatting it:

<img width="1012" height="432" alt="image" src="https://github.com/user-attachments/assets/1c667c35-3a8a-4402-9015-1304e462bd01" />
