### PR TITLE
feat: allow dependabot to set Jira ticket ID at the begining of PR title #PLTM-1047

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -51,7 +51,8 @@ const parallelRequests = (tasks, req) => {
 
 const checkTasks = async () => {
   const source = danger.github.pr.title;
-  const tasks = getTasks(source);
+  const author = danger.github.pr.user.login;
+  const tasks = getTasks(source, author);
   const allTasks = await parallelRequests(tasks, async ({ taskId }) => {
     return {
       taskId: taskId,
@@ -61,9 +62,13 @@ const checkTasks = async () => {
 
   const tasksWithName = allTasks.filter(({ name }) => name);
   if (tasksWithName.length === 0) {
+    const isDependabot = author === 'dependabot[bot]';
+    const positionText = isDependabot ? 'at the beginning' : 'at the end';
+    const exampleText = isDependabot ? '#DATA-98 Update package' : 'PR title #DATA-98';
+
     fail(`
       <p>
-        <b>Please add the Jira issue key at the end of PR title e.g.: #DATA-98</b> (remember to add hash)
+        <b>Please add the Jira issue key ${positionText} of PR title e.g.: ${exampleText}</b> (remember to add hash)
       </p>
       <p>
         <i>

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -1,13 +1,18 @@
 /**
  * Acceptable formats:
- * - #CORE-123
+ * - #CORE-123 (at the end for regular PRs, at the beginning for dependabot[bot] PRs)
  */
-const getTasks = (source) => {
-  // Matches the prefix of the string containg only issue references delimited with whitespaces
-  const prefixWithRefsRegex = /((\s+|^)#[A-Z]{2,10}-\d+)+\s*$/;
+const getTasks = (source, author = null) => {
+  const isDependabot = author === 'dependabot[bot]';
+
+  // Choose regex pattern based on author type
+  const prefixWithRefsRegex = isDependabot
+    ? /^((\s*#[A-Z]{2,10}-\d+)+\s*)/  // Beginning for dependabot
+    : /((\s+|^)#[A-Z]{2,10}-\d+)+\s*$/; // End for regular PRs
+
+  const taskRefRegex = /(?<=(\s|^)#)[A-Z]{2,10}-\d+/g;  // Requires # for all PRs
+
   const [prefix] = source.match(prefixWithRefsRegex) || [""];
-  // Picks individual issue references from the string
-  const taskRefRegex = /(?<=(\s|^)#)[A-Z]{2,10}-\d+/g;
   const refs = prefix.match(taskRefRegex) || [];
   const uniqueRefs = new Set(refs);
 

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -7,7 +7,7 @@ const getTasks = (source, author = null) => {
 
   // Choose regex pattern based on author type
   const prefixWithRefsRegex = isDependabot
-    ? /^((\s*#[A-Z]{2,10}-\d+)+\s*)/  // Beginning for dependabot
+    ? /^((\s+|^)#[A-Z]{2,10}-\d+)+\s*/  // Beginning for dependabot
     : /((\s+|^)#[A-Z]{2,10}-\d+)+\s*$/; // End for regular PRs
 
   const taskRefRegex = /(?<=(\s|^)#)[A-Z]{2,10}-\d+/g;  // Requires # for all PRs

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -10,9 +10,9 @@ const getTasks = (source, author = null) => {
     ? /^((\s+|^)#[A-Z]{2,10}-\d+)+\s*/  // Beginning for dependabot
     : /((\s+|^)#[A-Z]{2,10}-\d+)+\s*$/; // End for regular PRs
 
-  const taskRefRegex = /(?<=(\s|^)#)[A-Z]{2,10}-\d+/g;  // Requires # for all PRs
-
   const [prefix] = source.match(prefixWithRefsRegex) || [""];
+  // Picks individual issue references from the string
+  const taskRefRegex = /(?<=(\s|^)#)[A-Z]{2,10}-\d+/g;
   const refs = prefix.match(taskRefRegex) || [];
   const uniqueRefs = new Set(refs);
 

--- a/lib/get-tasks.spec.js
+++ b/lib/get-tasks.spec.js
@@ -41,6 +41,41 @@ const correctSources = [
   ],
 ];
 
+const correctDependabotSources = [
+  [
+    "#BUNNY-1 Update package",
+    [
+      { taskId: "BUNNY-1" }
+    ]
+  ],
+  [
+    "#BUNNY-1   Update package",
+    [
+      { taskId: "BUNNY-1" }
+    ]
+  ],
+  [
+    "#BUNNY-1 #BUNNY-1 Update package",
+    [
+      { taskId: "BUNNY-1" },
+    ]
+  ],
+  [
+    "#CORE-123 #BUNNY-1 Update package",
+    [
+      { taskId: "CORE-123" },
+      { taskId: "BUNNY-1" },
+    ]
+  ],
+  [
+    "#CORE-123   #BUNNY-1 Update package",
+    [
+      { taskId: "CORE-123" },
+      { taskId: "BUNNY-1" },
+    ]
+  ],
+];
+
 const incorrectSources = [
   "This PR has too short custom ticket reference #C-123",
   "There is no # in this ticket reference CORE-123",
@@ -49,18 +84,44 @@ const incorrectSources = [
   "Ticket reference #BUNNY-1 is in the middle of the title",
 ];
 
+const incorrectDependabotSources = [
+  "Update package #BUNNY-1",
+  "Update package BUNNY-1",
+  "Update package #BUNNY-1 #CORE-123",
+  "Update package #BUNNY-1 in the middle",
+  "Update package with #BUNNY-1 at the end",
+  "BUNNY-1 Update package",
+  "CORE-123 BUNNY-1 Update package",
+];
+
 const emptySource = "A PR without ticket references";
 
 describe('getTasks', () => {
-  it.each(correctSources)('extracts ticket references', (source, expectedTaskObjects) => {
-    expect(getTasks(source)).toEqual(expectedTaskObjects);
+  describe('for regular PRs', () => {
+    it.each(correctSources)('extracts ticket references from the end', (source, expectedTaskObjects) => {
+      expect(getTasks(source)).toEqual(expectedTaskObjects);
+    });
+
+    it.each(incorrectSources)('should return empty list when ticket references that do not match the format', (source) => {
+      expect(getTasks(source)).toEqual([]);
+    });
+
+    it('should return empty list for PRs with no ticket references', () => {
+      expect(getTasks(emptySource)).toEqual([]);
+    });
   });
 
-  it.each(incorrectSources)('should return empty list when ticket references that do not match the format', (source) => {
-    expect(getTasks(source)).toEqual([]);
-  });
+  describe('for dependabot[bot] PRs', () => {
+    it.each(correctDependabotSources)('extracts ticket references from the beginning', (source, expectedTaskObjects) => {
+      expect(getTasks(source, 'dependabot[bot]')).toEqual(expectedTaskObjects);
+    });
 
-  it('should return empty list for PRs with no ticket references', () => {
-    expect(getTasks(emptySource)).toEqual([]);
+    it.each(incorrectDependabotSources)('should return empty list when ticket references are not at the beginning', (source) => {
+      expect(getTasks(source, 'dependabot[bot]')).toEqual([]);
+    });
+
+    it('should return empty list for dependabot PRs with no ticket references', () => {
+      expect(getTasks(emptySource, 'dependabot[bot]')).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Overview

This PR modifies the Jira ticket reference validation logic to support dependabot[bot] PRs, which have limitations that prevent them from adding Jira ticket references at the end of PR titles.

## Problem

Dependabot has a known limitation where it cannot append text to the end of PR titles. When dependabot creates PRs for dependency updates, it can only modify the beginning of the title, making it impossible to add Jira ticket references at the end as required by our current validation rules.

## Solution

Modified the `getTasks` function to handle different PR author types:

- **Regular PRs**: Continue to require Jira ticket references at the end of the title (e.g., `PR title #DATA-98`)
- **dependabot[bot] PRs**: Require Jira ticket references at the beginning of the title (e.g., `#DATA-98 Update package`)

## Changes Made

### `lib/get-tasks.js`
- Added optional `author` parameter to `getTasks` function
- Implemented conditional regex patterns based on PR author type

### `dangerfile.js`
- Pass PR author information to `getTasks` function
- Updated error messages to be context-aware, showing different instructions for dependabot vs regular PRs

### `lib/get-tasks.spec.js`
- Added comprehensive test cases for dependabot PRs
- Added test cases for invalid dependabot PRs (references not at beginning)
- Organized tests into separate describe blocks for different author types
- All 25 tests pass successfully

## Technical Details

### Regex Patterns
- **Regular PRs**: `/((\s+|^)#[A-Z]{2,10}-\d+)+\s*$/` (matches end of title)
- **Dependabot PRs**: `/^((\s+|^)#[A-Z]{2,10}-\d+)+\s*/` (matches beginning of title)

### Validation Rules
- All PR authors must use the `#` symbol before Jira ticket references
- Regular PRs: References must be at the end of the title
- Dependabot PRs: References must be at the beginning of the title
- Multiple references are supported for both author types

## Testing

### Regular PRs
```
✅ "Add new feature #DATA-98"
✅ "Fix bug in authentication #CORE-123 #SEC-456"
❌ "Add new feature" (no ticket reference)
❌ "Add new feature #DATA-98 but reference in middle"
```

### Dependabot PRs
```
✅ "#DATA-98 Update lodash to 4.17.21"
✅ "#CORE-123 #SEC-456 Update multiple packages"
❌ "Update lodash to 4.17.21 #DATA-98" (reference at end)
❌ "Update lodash to 4.17.21" (no ticket reference)
```

## Impact

This change enables dependabot to create PRs that comply with our Jira ticket reference requirements, ensuring that all dependency updates are properly tracked and linked to Jira issues for project management and audit purposes.
