### PR TITLE
fix(ci): pin Node 22.22.3 in Kanar workflow to avoid ERR_STREAM_PREMATURE_CLOSE #PLTM-1403

### DIFF
--- a/.github/workflows/kanar.yml
+++ b/.github/workflows/kanar.yml
@@ -14,6 +14,9 @@ jobs:
   kanar:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22.22.3"
       - uses: RampNetwork/kanar@2e8718c3a1400156d59376bcdf678fa34e6e3b32 # v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }} # this is passed automatically https://docs.github.com/en/actions/security-guides/automatic-token-authentication


### PR DESCRIPTION
## Motivation

Kanar (Danger-based CI) fails intermittently on PRs with `ERR_STREAM_PREMATURE_CLOSE` / "Failed to fetch GitHub pull request files / commits" before the dangerfile runs. GitHub Actions runner images were updated around 23 June 2026, bumping the default Node on `ubuntu-latest` from **22.22.3** to **22.23.0**. Node **22.23.0+** and **24.17.0+** regressed `http.Agent` keep-alive behavior ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989), CVE-2026-48931), which breaks `node-fetch@2` used by Danger 13.x ([danger/danger-js#1515](https://github.com/danger/danger-js/issues/1515)).

## Intended outcome

Kanar should reliably fetch PR metadata from GitHub instead of failing with premature stream close errors caused by the broken Node keep-alive behavior on runner default Node versions.

## Overview of changes

- Add SHA-pinned `actions/setup-node@v4` before the `RampNetwork/kanar` step in `.github/workflows/kanar.yml`.
- Pin `node-version` to `"22.22.3"` (last known good version on the `ubuntu-latest` default Node 22 line).
- No other workflow changes; temporary workaround until [danger/danger-js#1516](https://github.com/danger/danger-js/pull/1516) or a patched Node release ([nodejs/node#64004](https://github.com/nodejs/node/pull/64004)).

## Quality assurance

- **Risk:** Low — single-step addition that downgrades Node from 22.23.0 to 22.22.3 for this job only; no app or build pipeline impact.
- **Follow-up:** Remove the pin once Danger ships a fix or Node releases a patched version.